### PR TITLE
Ensure resource paths are use UNIX notation

### DIFF
--- a/cmd/karavel/render.go
+++ b/cmd/karavel/render.go
@@ -16,11 +16,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/karavel-io/cli/pkg/action"
 	"github.com/karavel-io/cli/pkg/logger"
 	"github.com/spf13/cobra"
-	"os"
-	"path/filepath"
 )
 
 const DefaultFileName = "karavel.hcl"

--- a/internal/utils/kustomize.go
+++ b/internal/utils/kustomize.go
@@ -16,14 +16,15 @@ package utils
 
 import (
 	"bytes"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
-	"modernc.org/sortutil"
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/kustomize/api/types"
 	"sort"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	"modernc.org/sortutil"
+	"sigs.k8s.io/kustomize/api/types"
 )
 
 func RenderKustomizeFile(outdir string, resources []string, ignoreFn func(s string) bool) error {
@@ -64,6 +65,13 @@ func RenderKustomizeFile(outdir string, resources []string, ignoreFn func(s stri
 	kfile.Resources = resources
 
 	kfile.FixKustomizationPreMarshalling()
+
+	// Cleanup paths and make sure they're using unix-style separators
+	// This is mostly useful for Windows, other OSs shouldn't worry about this
+	for index, resource := range kfile.Resources {
+		resource = filepath.ToSlash(filepath.Clean(resource))
+		kfile.Resources[index] = resource
+	}
 
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)

--- a/pkg/action/render.go
+++ b/pkg/action/render.go
@@ -16,6 +16,14 @@ package action
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
 	"github.com/karavel-io/cli/internal/gitutils"
 	"github.com/karavel-io/cli/internal/helmw"
 	"github.com/karavel-io/cli/internal/plan"
@@ -24,13 +32,6 @@ import (
 	"github.com/karavel-io/cli/pkg/config"
 	"github.com/karavel-io/cli/pkg/logger"
 	"github.com/pkg/errors"
-	"io/ioutil"
-	"os"
-	"path"
-	"path/filepath"
-	"sort"
-	"strings"
-	"sync"
 )
 
 type RenderParams struct {


### PR DESCRIPTION
Karavel CLI currently uses host OS path format, which needs to be converted to UNIX paths before being written into the files.