### PR TITLE
Hotfix for helm paths on Windows

### DIFF
--- a/internal/helmw/chart.go
+++ b/internal/helmw/chart.go
@@ -17,12 +17,15 @@ package helmw
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
 	helmclient "github.com/mittwald/go-helm-client"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
-	"io"
 )
 
 func GetChartManifest(chartName string, version string, unstable bool) (*chart.Metadata, error) {
@@ -33,7 +36,10 @@ func GetChartManifest(chartName string, version string, unstable bool) (*chart.M
 
 	chartName = fmt.Sprintf("%s/%s", repo, chartName)
 	hc, err := helmclient.New(&helmclient.Options{
-		Debug: true,
+		//TODO replace this with a proper temp implementation
+		RepositoryCache:  filepath.Join(os.TempDir(), "helmcache"),
+		RepositoryConfig: filepath.Join(os.TempDir(), "helmconfig"),
+		Debug:            true,
 	})
 	if err != nil {
 		return nil, err
@@ -64,7 +70,10 @@ func TemplateChart(name string, namespace string, version string, values string,
 		repo = UnstableRepoName()
 	}
 	hc, err := helmclient.New(&helmclient.Options{
-		Debug: true,
+		//TODO replace this with a proper temp implementation
+		RepositoryCache:  filepath.Join(os.TempDir(), "helmcache"),
+		RepositoryConfig: filepath.Join(os.TempDir(), "helmconfig"),
+		Debug:            true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/helmw/helm.go
+++ b/internal/helmw/helm.go
@@ -16,6 +16,9 @@ package helmw
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	helmclient "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/repo"
 )
@@ -28,7 +31,11 @@ func SetupHelm(version string, repoUrl string) error {
 		return fmt.Errorf("version cannot be empty")
 	}
 
-	h, err := helmclient.New(&helmclient.Options{})
+	h, err := helmclient.New(&helmclient.Options{
+		//TODO replace this with a proper temp implementation
+		RepositoryCache:  filepath.Join(os.TempDir(), "helmcache"),
+		RepositoryConfig: filepath.Join(os.TempDir(), "helmconfig"),
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/plan/component.go
+++ b/internal/plan/component.go
@@ -18,6 +18,14 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
 	"github.com/karavel-io/cli/internal/argo"
 	"github.com/karavel-io/cli/internal/helmw"
 	"github.com/karavel-io/cli/internal/utils"
@@ -28,13 +36,6 @@ import (
 	"github.com/tidwall/sjson"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/chart"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"sort"
-	"strconv"
-	"strings"
-	"sync"
 )
 
 const (


### PR DESCRIPTION
go-helm-client uses hardcoded /tmp paths as default cache/config, which doesn't work on Windows. This uses a dirty temporary fix (`os.TempDir` is not guaranteed to be a real working directory but probably is) while we wait for a better one ie. either forking or replacing go-helm-client)