### PR TITLE
Change how init works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Init now uses the GitHub tags API to fetch the latest version and generates an empty `karavel.hcl`, instead of trying to download an example file from the release.
+
 ## [0.2.1] 2022-03-08
 
 ### Fixed

--- a/cmd/karavel/init.go
+++ b/cmd/karavel/init.go
@@ -28,7 +28,7 @@ func NewInitCommand() *cobra.Command {
 	var ver string
 	var filename string
 	var force bool
-	var cfgUrl string
+	var repo string
 
 	cmd := &cobra.Command{
 		Use:   "init [WORKDIR]",
@@ -55,11 +55,11 @@ func NewInitCommand() *cobra.Command {
 			ver = strings.TrimPrefix(ver, "v")
 
 			return action.Initialize(cmd.Context(), action.InitParams{
-				Workdir:         cwd,
-				Filename:        filename,
-				KaravelVersion:  ver,
-				Force:           force,
-				FileUrlOverride: cfgUrl,
+				Workdir:        cwd,
+				Filename:       filename,
+				KaravelVersion: ver,
+				Force:          force,
+				GitHubRepo:     repo,
 			})
 		},
 	}
@@ -67,7 +67,7 @@ func NewInitCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&ver, "version", "v", "latest", "Karavel Container Platform version to initialize")
 	cmd.Flags().StringVarP(&filename, "output-file", "o", DefaultFileName, "Karavel config file name to create")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite the config file even if it already exists")
-	cmd.Flags().StringVar(&cfgUrl, "config-url", "", "Override the official URL pointing to the Karavel config file to download")
+	cmd.Flags().StringVar(&repo, "github-repo", "", "Override the official GitHub repository containing the tagged Platform releases")
 
 	return cmd
 }

--- a/internal/argo/app.go
+++ b/internal/argo/app.go
@@ -17,9 +17,10 @@ package argo
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Application is a lightweight struct matching argoproj.io/v1alpha1/Application
@@ -131,7 +132,7 @@ func (app *Application) Render(outfile string) error {
 		return fmt.Errorf("%s: %w", deferr, err)
 	}
 
-	if err := ioutil.WriteFile(outfile, buf.Bytes(), 0655); err != nil {
+	if err := ioutil.WriteFile(outfile, buf.Bytes(), 0o655); err != nil {
 		return fmt.Errorf("%s: %w", deferr, err)
 	}
 	return nil

--- a/internal/github/releases.go
+++ b/internal/github/releases.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 )
 
-const ErrSetup = "failed to construct HTTP request from GitHub API"
-const ErrHttp = "failed to fetch releases from GitHub API"
-const ErrJson = "failed to decode JSON response from GitHub API"
+const (
+	ErrSetup = "failed to construct HTTP request from GitHub API"
+	ErrHttp  = "failed to fetch releases from GitHub API"
+	ErrJson  = "failed to decode JSON response from GitHub API"
+)
 
 type ghError struct {
 	Message string `json:"message"`

--- a/internal/github/releases.go
+++ b/internal/github/releases.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 )
 
 const ErrGitHubApi = "failed to fetch releases from GitHub API"
@@ -54,5 +55,14 @@ func FetchLatestRelease(ctx context.Context, apiUrl string) (string, error) {
 }
 
 func sortReleases(releases []string) {
+	for i, rel := range releases {
+		if !strings.Contains(rel, "-rc") {
+			releases[i] = rel + "-zzz" // This is so that 2022.5 is sorted before 2022.5-rc.1
+		}
+	}
 	sort.Sort(sort.Reverse(sort.StringSlice(releases)))
+
+	for i, rel := range releases {
+		releases[i] = strings.TrimSuffix(rel, "-zzz")
+	}
 }

--- a/internal/github/releases_test.go
+++ b/internal/github/releases_test.go
@@ -1,0 +1,15 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortReleases(t *testing.T) {
+	rels := []string{"2022.1", "2021.2", "2022.5-rc.1", "2022.5-rc.7", "2022.4-rc.2"}
+	exp := []string{"2022.5-rc.7", "2022.5-rc.1", "2022.4-rc.2", "2022.1", "2021.2"}
+
+	sortReleases(rels)
+	assert.Equal(t, exp, rels)
+}

--- a/internal/github/releases_test.go
+++ b/internal/github/releases_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestSortReleases(t *testing.T) {
-	rels := []string{"2022.1", "2021.2", "2022.5-rc.1", "2022.5-rc.7", "2022.4-rc.2"}
-	exp := []string{"2022.5-rc.7", "2022.5-rc.1", "2022.4-rc.2", "2022.1", "2021.2"}
+	rels := []string{"2022.1", "2021.2", "2022.5-rc.1", "2022.5", "2022.5-rc.7", "2022.4-rc.2"}
+	exp := []string{"2022.5", "2022.5-rc.7", "2022.5-rc.1", "2022.4-rc.2", "2022.1", "2021.2"}
 
 	sortReleases(rels)
 	assert.Equal(t, exp, rels)

--- a/internal/helmw/chart.go
+++ b/internal/helmw/chart.go
@@ -71,7 +71,7 @@ func TemplateChart(ctx context.Context, name string, options ChartOptions) ([]Ya
 	chartName := fmt.Sprintf("%s/%s", repo, name)
 
 	settings := settingsFromContext(ctx)
-	//providers := getter.All(settings)
+	// providers := getter.All(settings)
 	logger := logger.FromContext(ctx)
 
 	config := new(action.Configuration)

--- a/internal/helmw/context.go
+++ b/internal/helmw/context.go
@@ -25,8 +25,10 @@ import (
 
 type contextKey string
 
-var repoKey contextKey = "helmw.repo"
-var settingsKey contextKey = "helmw.settings"
+var (
+	repoKey     contextKey = "helmw.repo"
+	settingsKey contextKey = "helmw.settings"
+)
 
 func FromContext(ctx context.Context) *repo.File {
 	val, ok := ctx.Value(repoKey).(*repo.File)

--- a/internal/helmw/helm.go
+++ b/internal/helmw/helm.go
@@ -23,12 +23,12 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 )
 
-const HelmRepoName = "karavel"
-const HelmDefaultRepo = "https://repository.platform.karavel.io"
-
-var (
-	ErrVersionEmpty = fmt.Errorf("version cannot be empty")
+const (
+	HelmRepoName    = "karavel"
+	HelmDefaultRepo = "https://repository.platform.karavel.io"
 )
+
+var ErrVersionEmpty = fmt.Errorf("version cannot be empty")
 
 func NewRepo(version string, repoUrl string) (*repo.Entry, error) {
 	if version == "" {
@@ -78,7 +78,7 @@ func WithRepository(ctx context.Context, entry *repo.Entry) (context.Context, er
 	store.Update(entry)
 
 	// Write updated config to file
-	err = store.WriteFile(settings.RepositoryConfig, 0644)
+	err = store.WriteFile(settings.RepositoryConfig, 0o644)
 	if err != nil {
 		return ctx, err
 	}

--- a/internal/plan/component.go
+++ b/internal/plan/component.go
@@ -172,7 +172,7 @@ func (c *Component) Render(ctx context.Context, log logger.Logger, outdir string
 		return fmt.Errorf(errorFormat, c.name, c.version, err)
 	}
 
-	if err := os.MkdirAll(outdir, 0755); err != nil {
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
 		return fmt.Errorf(errorFormat, c.name, c.version, err)
 	}
 
@@ -232,7 +232,7 @@ func (c *Component) Render(ctx context.Context, log logger.Logger, outdir string
 			basename := fmt.Sprintf("%s-%s%s.yml", k, meta["name"], ns)
 			filename := filepath.Join(outdir, basename)
 			log.Debugf("component %s writing file %s", c.DebugLabel(), filepath.Join(filepath.Base(outdir), basename))
-			if err := ioutil.WriteFile(filename, buf.Bytes(), 0655); err != nil {
+			if err := ioutil.WriteFile(filename, buf.Bytes(), 0o655); err != nil {
 				resch <- routineRes{err: err}
 			}
 

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -30,7 +30,8 @@ type Plan struct {
 	log            logger.Logger
 }
 
-func NewFromConfig(ctx context.Context, log logger.Logger, cfg *config.Config) (*Plan, error) {
+func NewFromConfig(ctx context.Context, cfg *config.Config) (*Plan, error) {
+	log := logger.FromContext(ctx)
 	p := New(log)
 
 	var wg sync.WaitGroup

--- a/internal/utils/download.go
+++ b/internal/utils/download.go
@@ -37,7 +37,7 @@ func DownloadWithProgress(ctx context.Context, log logger.Logger, url string, fi
 
 	start := time.Now()
 
-	out, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0666)
+	out, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0o666)
 	if err != nil {
 		return err
 	}

--- a/internal/utils/kustomize.go
+++ b/internal/utils/kustomize.go
@@ -84,7 +84,7 @@ func RenderKustomizeFile(outdir string, resources []string, ignoreFn func(s stri
 		return err
 	}
 
-	if err := ioutil.WriteFile(filename, buf.Bytes(), 0655); err != nil {
+	if err := ioutil.WriteFile(filename, buf.Bytes(), 0o655); err != nil {
 		return err
 	}
 

--- a/pkg/action/initialize.go
+++ b/pkg/action/initialize.go
@@ -72,7 +72,7 @@ func Initialize(ctx context.Context, params InitParams) error {
 	log.Infof("Fetching starting config from %s", cfgUrl)
 	log.Info()
 
-	if err := os.MkdirAll(workdir, 0755); err != nil {
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
 		return err
 	}
 
@@ -100,7 +100,7 @@ func Initialize(ctx context.Context, params InitParams) error {
 
 	log.Info()
 	log.Infof("Writing config file to %s", filedst)
-	return ioutil.WriteFile(filedst, cfg, 0655)
+	return ioutil.WriteFile(filedst, cfg, 0o655)
 }
 
 func download(ctx context.Context, log logger.Logger, url string) ([]byte, error) {

--- a/pkg/action/render.go
+++ b/pkg/action/render.go
@@ -90,7 +90,7 @@ func Render(ctx context.Context, params RenderParams) error {
 	defer helmw.Clean(ctx)
 
 	log.Debug("Creating render plan from config")
-	p, err := plan.NewFromConfig(ctx, log, &cfg)
+	p, err := plan.NewFromConfig(ctx, &cfg)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate render plan from config: %w", err)
 	}
@@ -113,7 +113,7 @@ func Render(ctx context.Context, params RenderParams) error {
 
 	for _, dir := range assertDirs {
 		log.Debugf("Asserting directory %s", dir)
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", dir, err)
 		}
 	}
@@ -147,12 +147,12 @@ func Render(ctx context.Context, params RenderParams) error {
 			return err
 		}
 
-		path, err := filepath.Rel(dir, workdir)
+		file, err := filepath.Rel(dir, workdir)
 		if err != nil {
 			return err
 		}
 
-		repoPath, repoUrl = path, url
+		repoPath, repoUrl = file, url
 	}
 
 	// empty line for nice logs
@@ -241,7 +241,7 @@ func Render(ctx context.Context, params RenderParams) error {
 		}
 
 		infraProj := "infrastructure.yml"
-		if err := ioutil.WriteFile(filepath.Join(projsDir, infraProj), []byte(fmt.Sprintf(argoProject, argoNs)), 0655); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(projsDir, infraProj), []byte(fmt.Sprintf(argoProject, argoNs)), 0o655); err != nil {
 			return fmt.Errorf("failed to render infrastructure project file: %w", err)
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,9 +28,7 @@ import (
 	"github.com/zclconf/go-cty/cty/json"
 )
 
-var (
-	ErrConfigParseFailed = errors.New("failed to parse Karavel config")
-)
+var ErrConfigParseFailed = errors.New("failed to parse Karavel config")
 
 type Config struct {
 	Version            string      `hcl:"version"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,7 +38,7 @@ func (*ConfigTestSuite) prepareConfig(cfg string) *os.File {
 		panic(f)
 	}
 
-	if err := ioutil.WriteFile(f.Name(), []byte(cfg), 0600); err != nil {
+	if err := ioutil.WriteFile(f.Name(), []byte(cfg), 0o600); err != nil {
 		panic(err)
 	}
 

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let
 in
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    go_1_17
+    unstable.go_1_18
     addlicense
     gnumake
     unstable.goreleaser


### PR DESCRIPTION
The current version of `karavel init` downloads an example `karavel.hcl` file from the GitHub release artefacts. This is both annoying because it requires us to upload said file to every release, and impractical as there are many different combinations of components one may want to install, and providing one "recommended" config would defeat the purpose of the component system.

The new version instead generates the `karavel.hcl` file from an embedded template that is currently defined as follows:

```
version = "{{ . }}"

#  Now you can add some Karavel components to install in your cluster.
#  For a list of available components consult https://platform.karavel.io/components/
#
#  component "example" {
#    namespace = "example"
#
#    some = "param"
#    other = {
#      configuration = "values"
#    }
#  }
```

The version is injected from either the CLI flag (e.g. `karavel init --version 2099.9` or, if empty or `latest`, fetched from the GitHub Tags API for the repo `karavel-io/platform` (although this is overridable). Support for other VCSs is out of scope.

The sorting algorithm for getting the latest release (which cannot be provided by GitHub as their concept of `latest` is purely temporal, so if `2022.3.1` gets published after `2022.4.0` it is considered "latest") is an implementation detail, but it is currently implemented as a simple string sort with a special case for handling the order of non-rc releases (so that e.g. `2022.5` comes before `2022.5-rc.1`). This seems to work well with CalVer without the need for a custom parser.