### PR TITLE
Make namespace optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: The `namespace` field in `karavel.hcl` has been made optional by falling back to the `namespace` value in each component's chart. This means components *must* provide it or rendering will fail when the namespace is omitted!
+
 ## [0.3.0] - 2022-06-22
 
 ### Changed

--- a/internal/helmw/chart.go
+++ b/internal/helmw/chart.go
@@ -119,6 +119,19 @@ func TemplateChart(ctx context.Context, name string, options ChartOptions) ([]Ya
 		return nil, fmt.Errorf("could not decode values: %w", err)
 	}
 
+	// If a custom namespace is not specified, get the one in values
+	if install.Namespace == "" {
+		defaultNamespaceRaw, ok := chart.Values["namespace"]
+		if !ok {
+			return nil, fmt.Errorf("could not determine default namespace: missing required 'namespace' in component chart")
+		}
+		defaultNamespace, ok := defaultNamespaceRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf("could not determine default namespace: 'namespace' field in component chart is not a string")
+		}
+		install.Namespace = defaultNamespace
+	}
+
 	// Run install and generate manifests
 	release, err := install.Run(chart, values)
 	if err != nil {

--- a/pkg/action/render.go
+++ b/pkg/action/render.go
@@ -81,8 +81,8 @@ func Render(ctx context.Context, params RenderParams) error {
 		return fmt.Errorf("failed to setup Karavel stable components repository: %w", err)
 	}
 
-	log.Debugf("Updating Karavel components unstable repository %s", cfg.HelmUntableRepoUrl)
-	ctx, err = addRepo(ctx, "unstable", cfg.HelmUntableRepoUrl)
+	log.Debugf("Updating Karavel components unstable repository %s", cfg.HelmUnstableRepoUrl)
+	ctx, err = addRepo(ctx, "unstable", cfg.HelmUnstableRepoUrl)
 	if err != nil {
 		return fmt.Errorf("failed to setup Karavel stable components repository: %w", err)
 	}

--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -19,7 +19,7 @@ import "github.com/hashicorp/hcl/v2"
 type Component struct {
 	Name          string                    `hcl:"name,label"`
 	ComponentName string                    `hcl:"component,optional"`
-	Namespace     string                    `hcl:"namespace"`
+	Namespace     string                    `hcl:"namespace,optional"`
 	Version       string                    `hcl:"version,optional"`
 	RawParams     map[string]*hcl.Attribute `hcl:",remain"`
 	JsonParams    string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,10 +31,10 @@ import (
 var ErrConfigParseFailed = errors.New("failed to parse Karavel config")
 
 type Config struct {
-	Version            string      `hcl:"version"`
-	Components         []Component `hcl:"component,block"`
-	HelmStableRepoUrl  string      `hcl:"stable_repo,optional"`
-	HelmUntableRepoUrl string      `hcl:"unstable_repo,optional"`
+	Version             string      `hcl:"version"`
+	Components          []Component `hcl:"component,block"`
+	HelmStableRepoUrl   string      `hcl:"stable_repo,optional"`
+	HelmUnstableRepoUrl string      `hcl:"unstable_repo,optional"`
 }
 
 func ReadFrom(logw io.Writer, filename string) (Config, error) {
@@ -87,7 +87,7 @@ func ReadFrom(logw io.Writer, filename string) (Config, error) {
 	}
 
 	c.HelmStableRepoUrl = helmw.GetRepoUrl(c.Version, c.HelmStableRepoUrl)
-	c.HelmUntableRepoUrl = helmw.GetRepoUrl("unstable", c.HelmUntableRepoUrl)
+	c.HelmUnstableRepoUrl = helmw.GetRepoUrl("unstable", c.HelmUnstableRepoUrl)
 
 	return c, nil
 }


### PR DESCRIPTION
Tracking issue: https://github.com/karavel-io/platform/issues/20

Makes the `namespace` field in `karavel.hcl` optional by falling back to the `namespace` value in `values.yaml`

## THIS IS A BREAKING CHANGE

This change breaks compatibility with all stable versions of all the current components! We should release a new version of components and warn against using old versions before releasing a new version of the CLI!