### PR TITLE
Fix hooks processing

### DIFF
--- a/internal/github/releases.go
+++ b/internal/github/releases.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Karavel Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package github
 
 import (

--- a/internal/github/releases_test.go
+++ b/internal/github/releases_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Karavel Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package github
 
 import (


### PR DESCRIPTION
This fixes a regression where Helm Hooks were not included in the `release.Manifests` YAML-encoded string, and were therefore missing in the rendered files.